### PR TITLE
fix: Sync dtype of x to support_vector

### DIFF
--- a/sk2torch/svc.py
+++ b/sk2torch/svc.py
@@ -188,6 +188,8 @@ class TorchSVC(nn.Module):
         self, x: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Compute the one-versus-one and one-versus-rest decision functions."""
+        if x.dtype != self.support_vectors.dtype:
+            x = x.to(self.support_vectors.dtype)
         kernel_out = self.kernel(x, self.support_vectors)
 
         votes = torch.zeros((len(x), self.n_classes)).to(kernel_out)


### PR DESCRIPTION
@unixpickle 
### Bug describe:
I use `sklearn.svm .SVC`  model and `torch_model = sk2torch.wrap(model)` to get the pytorch model of svm. I use `torch_model(X)`to do predict task. Got this error:
```
Traceback (most recent call last):
  File "/home/ps/wufei/eeg-gnn-ssl/faced/svm_EEG_TOPO_FACED.py", line 188, in <module>
    torch_model(one_freq_mask)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/sk2torch/svc.py", line 80, in forward
    return self.predict(x)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/sk2torch/svc.py", line 84, in predict
    ovo, ovr = self.decision_function_ovo_ovr(x)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/sk2torch/svc.py", line 193, in decision_function_ovo_ovr
    kernel_out = self.kernel(x, self.support_vectors)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/anaconda3/envs/wf_lab/lib/python3.10/site-packages/sk2torch/kernel.py", line 47, in forward
    dots = x @ y.t()
RuntimeError: expected m1 and m2 to have the same dtype, but got: float != double
```
### My Solution:
this error is the support vector and input X’s dtype not matched, but in sklearn model ,float32 data works well. So I check the predict func of  svm model in sklearn, it convert the X to float64 in every predict call: 
![image](https://github.com/unixpickle/sk2torch/assets/63766429/6f685e74-5a5a-42e0-9f0a-37e024a37f51)
https://github.com/scikit-learn/scikit-learn/blob/dbebec7b228a2216032d8ceefe6f5f75deb00561/sklearn/svm/_base.py#L609
So I made a simple dtype convert to be compatible with sklearn and avoid this error.

 
